### PR TITLE
added symbols to the GOES plots to show where the data-points are.

### DIFF
--- a/RealTime/realtime_flare_trigger.py
+++ b/RealTime/realtime_flare_trigger.py
@@ -379,15 +379,15 @@ class RealTimeTrigger(QtWidgets.QWidget):
      
     def plot(self, x, y, color, plotname):
         pen = pg.mkPen(color=color, width=5)
-        return self.graphWidget.plot(x, self._log_data(y), name=plotname, pen=pen)
+        return self.graphWidget.plot(x, self._log_data(y), name=plotname, pen=pen, symbol="o", symbolSize=3)
         
     def tempplot(self, x, y, color, plotname):
         pen = pg.mkPen(color=color, width=5)
-        return self.tempgraph.plot(x, y, name=plotname, pen=pen)
+        return self.tempgraph.plot(x, y, name=plotname, pen=pen, symbol="o", symbolSize=3)
         
     def emplot(self, x, y, color, plotname):
         pen = pg.mkPen(color=color, width=5)
-        return self.emgraph.plot(x, y, name=plotname, pen=pen)
+        return self.emgraph.plot(x, y, name=plotname, pen=pen, symbol="o", symbolSize=3)
         
     def eovsaplot(self, x, y, color, plotname):
         pen = pg.mkPen(color=color, width=5)


### PR DESCRIPTION
For some discussion...

Lindsay suggested it could be nice to be able to see exactly where the GOES data-points are on the graph so I've quickly added something in to see how it looks.

Original plot is:
<img width="426" alt="no-symbols" src="https://github.com/pet00184/flarepred/assets/43237137/1679e70e-04e9-429c-aece-34faf9c0ac26">

With symbols marking the GOES data-points (also added to T and EM plot):
<img width="426" alt="symbols" src="https://github.com/pet00184/flarepred/assets/43237137/5478494f-0243-49c8-b965-da5c28cd6b64">
